### PR TITLE
Set jekyll version to current 2.x version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,7 +60,7 @@ if [ ! -f $BUILD_DIR/.gems/bin/jekyll ]; then
     echo "Jekyll not found!"
     echo "-----> Installing Jekyll"
     gem install liquid -v 2.2.2 --no-rdoc --no-ri | indent
-    gem install jekyll redcarpet sass --no-rdoc --no-ri | indent
+    gem install jekyll -v 2.5.3 redcarpet sass --no-rdoc --no-ri | indent
     gem install therubyracer --no-rdoc --no-ri | indent
 
 fi


### PR DESCRIPTION
Otherwise the current version (>= 3.0) is installed and this doesn't support Ruby < 2.0 any more.
Causing the buildpack to fail on push to Dokku.
